### PR TITLE
Add Anderson Memorial Bridge photo grid

### DIFF
--- a/nooahaha.css
+++ b/nooahaha.css
@@ -135,4 +135,16 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
 }
 .content p {
   margin: 0 0 20px 0;
-} 
+}
+
+/* Responsive photo grid for project images */
+.photo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+}
+.photo-grid img {
+  width: 100%;
+  height: auto;
+  display: block;
+}

--- a/nooahaha.js
+++ b/nooahaha.js
@@ -23,7 +23,7 @@ function updateNavIndicator(id){
 function sanitizeHTML(html){
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
-  const allowed = new Set(['p','a','em','strong','span','ul','ol','li','h1','h2','h3','h4','h5','h6','br']);
+  const allowed = new Set(['p','a','em','strong','span','ul','ol','li','h1','h2','h3','h4','h5','h6','br','div','img']);
   const walker = document.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT);
   const toRemove = [];
   while (walker.nextNode()){
@@ -34,7 +34,7 @@ function sanitizeHTML(html){
       const name = attr.name.toLowerCase();
       if (name === 'href' && tag === 'a') {
         if (/^javascript:/i.test(attr.value)) el.removeAttribute(attr.name);
-      } else if (name.startsWith('on') || !['href','target','rel','class','id'].includes(name)) {
+      } else if (name.startsWith('on') || !['href','target','rel','class','id','src','alt','loading'].includes(name)) {
         el.removeAttribute(attr.name);
       }
     });

--- a/projects.html
+++ b/projects.html
@@ -1,1 +1,45 @@
-<p><span class="clicker"></span></p> 
+<h3>Anderson Memorial Bridge</h3>
+<div class="photo-grid">
+  <img src="Projects/AMB%20Photos/amb01.jpg" alt="Anderson Memorial Bridge photo 1" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb02.jpg" alt="Anderson Memorial Bridge photo 2" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb03.jpg" alt="Anderson Memorial Bridge photo 3" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb04.jpg" alt="Anderson Memorial Bridge photo 4" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb05.jpg" alt="Anderson Memorial Bridge photo 5" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb06.jpg" alt="Anderson Memorial Bridge photo 6" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb07.jpg" alt="Anderson Memorial Bridge photo 7" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb08.jpg" alt="Anderson Memorial Bridge photo 8" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb09.jpg" alt="Anderson Memorial Bridge photo 9" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb10.jpg" alt="Anderson Memorial Bridge photo 10" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb11.jpg" alt="Anderson Memorial Bridge photo 11" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb12.jpg" alt="Anderson Memorial Bridge photo 12" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb13.jpg" alt="Anderson Memorial Bridge photo 13" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb14.jpg" alt="Anderson Memorial Bridge photo 14" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb15.jpg" alt="Anderson Memorial Bridge photo 15" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb16.jpg" alt="Anderson Memorial Bridge photo 16" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb17.jpg" alt="Anderson Memorial Bridge photo 17" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb18.jpg" alt="Anderson Memorial Bridge photo 18" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb19.jpg" alt="Anderson Memorial Bridge photo 19" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb20.jpg" alt="Anderson Memorial Bridge photo 20" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb21.jpg" alt="Anderson Memorial Bridge photo 21" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb22.jpg" alt="Anderson Memorial Bridge photo 22" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb23.jpg" alt="Anderson Memorial Bridge photo 23" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb24.jpg" alt="Anderson Memorial Bridge photo 24" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb25.jpg" alt="Anderson Memorial Bridge photo 25" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb26.jpg" alt="Anderson Memorial Bridge photo 26" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb27.jpg" alt="Anderson Memorial Bridge photo 27" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb28.jpg" alt="Anderson Memorial Bridge photo 28" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb29.jpg" alt="Anderson Memorial Bridge photo 29" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb30.jpg" alt="Anderson Memorial Bridge photo 30" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb31.jpg" alt="Anderson Memorial Bridge photo 31" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb32.jpg" alt="Anderson Memorial Bridge photo 32" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb33.jpg" alt="Anderson Memorial Bridge photo 33" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb34.jpg" alt="Anderson Memorial Bridge photo 34" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb35.jpg" alt="Anderson Memorial Bridge photo 35" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb36.jpg" alt="Anderson Memorial Bridge photo 36" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb37.jpg" alt="Anderson Memorial Bridge photo 37" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb38.jpg" alt="Anderson Memorial Bridge photo 38" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb39.jpg" alt="Anderson Memorial Bridge photo 39" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb40.jpg" alt="Anderson Memorial Bridge photo 40" loading="lazy" />
+  <img src="Projects/AMB%20Photos/amb41.jpg" alt="Anderson Memorial Bridge photo 41" loading="lazy" />
+</div>
+<span class="clicker"></span>


### PR DESCRIPTION
## Summary
- add placeholder Projects/AMB Photos directory
- display Anderson Memorial Bridge title with responsive photo grid
- allow image and div tags in sanitizer for project content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896724bfe088325af984ed969e1494b