### PR TITLE
Add dynamic Anderson Memorial Bridge photo grid

### DIFF
--- a/nooahaha.css
+++ b/nooahaha.css
@@ -137,14 +137,20 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
   margin: 0 0 20px 0;
 }
 
-/* Responsive photo grid for project images */
+/* Responsive 6x6 photo grid for project images */
 .photo-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 8px;
+}
+@media (max-width: 800px) {
+  .photo-grid {
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  }
 }
 .photo-grid img {
   width: 100%;
-  height: auto;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
   display: block;
 }

--- a/nooahaha.js
+++ b/nooahaha.js
@@ -45,10 +45,55 @@ function sanitizeHTML(html){
   toRemove.forEach(el => el.replaceWith(...el.childNodes));
   return doc.body.innerHTML;
 }
+
+function shuffle(arr){
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+async function initAmbPhotoGrid(){
+  const grid = document.getElementById('amb-photo-grid');
+  if (!grid) return;
+  try {
+    const resp = await fetch('Projects/AMB%20Photos/', { cache: 'no-store' });
+    if (!resp.ok) throw new Error('Failed to fetch photo list');
+    const text = await resp.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(text, 'text/html');
+    const images = Array.from(doc.querySelectorAll('a'))
+      .map(a => a.getAttribute('href'))
+      .filter(h => h && /\.(jpe?g|png|gif)$/i.test(h))
+      .map(h => `Projects/AMB%20Photos/${h}`);
+    if (images.length === 0) return;
+    let selected;
+    if (images.length >= 36) {
+      shuffle(images);
+      selected = images.slice(0, 36);
+    } else {
+      const pool = [];
+      while (pool.length < 36) pool.push(...images);
+      selected = pool.slice(0, 36);
+    }
+    grid.innerHTML = '';
+    selected.forEach(src => {
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = 'Anderson Memorial Bridge photo';
+      grid.appendChild(img);
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}
 async function loadSection(id){
   const sec = document.getElementById(id);
   if (!sec) return;
-  if (sec.dataset.loaded === 'true' || sec.dataset.loading === 'true') return;
+  if (sec.dataset.loading === 'true') return;
+  if (sec.dataset.loaded === 'true') {
+    if (id === 'projects') initAmbPhotoGrid();
+    return;
+  }
   const container = sec.querySelector('.content');
   if (!container) return;
   try {
@@ -58,6 +103,7 @@ async function loadSection(id){
     const html = await resp.text();
     const sanitized = sanitizeHTML(html);
     container.innerHTML = sanitized;
+    if (id === 'projects') initAmbPhotoGrid();
     sec.dataset.loaded = 'true';
   } catch (err) {
     container.innerHTML = `<p style="color:#c00">Failed to load content.</p>`;

--- a/projects.html
+++ b/projects.html
@@ -1,5 +1,3 @@
 <h3>Anderson Memorial Bridge</h3>
-<div class="photo-grid">
-
-</div>
+<div class="photo-grid" id="amb-photo-grid"></div>
 <span class="clicker"></span>


### PR DESCRIPTION
## Summary
- Dynamically populate a 6×6 Anderson Memorial Bridge photo grid from the `Projects/AMB Photos` folder
- Shuffle images and reload the grid on each visit to show a fresh random selection of 36 photos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896bd136818832580abdf9d48151f07