### PR TITLE
Add arrow-based project slider

### DIFF
--- a/nooahaha.css
+++ b/nooahaha.css
@@ -149,8 +149,42 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
   }
 }
 .photo-grid img {
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  object-fit: cover;
-  display: block;
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+    display: block;
+}
+
+/* Retro project slider */
+.projects-frame {
+  border: 2px solid #808080;
+  background: #fff;
+  overflow: hidden;
+}
+.projects-slider {
+  display: flex;
+  transition: transform 300ms ease;
+}
+.project-pane {
+  flex: 0 0 100%;
+  padding: 16px;
+}
+.project-pane h3 {
+  display: flex;
+  align-items: center;
+  margin: 0 0 16px 0;
+}
+.project-next {
+  margin-left: 8px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #fff #808080 #808080 #fff;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 2px 6px;
+}
+.project-next:active {
+  border-color: #808080 #fff #fff #808080;
+  background: #e0e0e0;
 }

--- a/nooahaha.js
+++ b/nooahaha.js
@@ -23,7 +23,7 @@ function updateNavIndicator(id){
 function sanitizeHTML(html){
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
-  const allowed = new Set(['p','a','em','strong','span','ul','ol','li','h1','h2','h3','h4','h5','h6','br','div','img']);
+  const allowed = new Set(['p','a','em','strong','span','ul','ol','li','h1','h2','h3','h4','h5','h6','br','div','img','button']);
   const walker = document.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT);
   const toRemove = [];
   while (walker.nextNode()){
@@ -34,7 +34,7 @@ function sanitizeHTML(html){
       const name = attr.name.toLowerCase();
       if (name === 'href' && tag === 'a') {
         if (/^javascript:/i.test(attr.value)) el.removeAttribute(attr.name);
-      } else if (name.startsWith('on') || !['href','target','rel','class','id','src','alt','loading'].includes(name)) {
+      } else if (name.startsWith('on') || !(name.startsWith('data-') || ['href','target','rel','class','id','src','alt','loading'].includes(name))) {
         el.removeAttribute(attr.name);
       }
     });
@@ -86,12 +86,36 @@ async function initAmbPhotoGrid(){
     console.error(err);
   }
 }
+
+function initProjectSlider(){
+  const frame = document.querySelector('.projects-frame');
+  if (!frame || frame.dataset.inited) return;
+  frame.dataset.inited = 'true';
+  const slider = frame.querySelector('.projects-slider');
+  const panes = slider.querySelectorAll('.project-pane');
+  let index = 0;
+  function show(idx){
+    index = (idx + panes.length) % panes.length;
+    slider.style.transform = `translateX(-${index * 100}%)`;
+    const activePane = panes[index];
+    if (activePane.querySelector('#amb-photo-grid')) initAmbPhotoGrid();
+  }
+  slider.addEventListener('click', e => {
+    if (e.target.classList.contains('project-next')) {
+      show(index + 1);
+    }
+  });
+  show(0);
+}
+
 async function loadSection(id){
   const sec = document.getElementById(id);
   if (!sec) return;
   if (sec.dataset.loading === 'true') return;
   if (sec.dataset.loaded === 'true') {
-    if (id === 'projects') initAmbPhotoGrid();
+    if (id === 'projects') {
+      initProjectSlider();
+    }
     return;
   }
   const container = sec.querySelector('.content');
@@ -103,7 +127,7 @@ async function loadSection(id){
     const html = await resp.text();
     const sanitized = sanitizeHTML(html);
     container.innerHTML = sanitized;
-    if (id === 'projects') initAmbPhotoGrid();
+    if (id === 'projects') initProjectSlider();
     sec.dataset.loaded = 'true';
   } catch (err) {
     container.innerHTML = `<p style="color:#c00">Failed to load content.</p>`;

--- a/projects.html
+++ b/projects.html
@@ -1,3 +1,13 @@
-<h3>Anderson Memorial Bridge</h3>
-<div class="photo-grid" id="amb-photo-grid"></div>
+<div class="projects-frame">
+  <div class="projects-slider">
+    <div class="project-pane">
+      <h3>Anderson Memorial Bridge <button class="project-next">&gt;&gt;&gt;</button></h3>
+      <div class="photo-grid" id="amb-photo-grid"></div>
+    </div>
+    <div class="project-pane">
+      <h3>Rhythm of COVID-19 <button class="project-next">&gt;&gt;&gt;</button></h3>
+      <p>An audio-visual exploration of pandemic data rhythms.</p>
+    </div>
+  </div>
+</div>
 <span class="clicker"></span>


### PR DESCRIPTION
## Summary
- Replace retro tabs with arrow-driven slider so each project displays individually
- Style slider and buttons with Windows 95-inspired visuals
- Initialize project slider in site script and load AMB photo grid when its slide shows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d53d87248325b9f81b13a9958c90