### PR TITLE
Switch projects with arrow toggles

### DIFF
--- a/nooahaha.css
+++ b/nooahaha.css
@@ -148,9 +148,32 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
     grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
   }
 }
+.photo-wrap {
+  overflow: hidden;
+}
 .photo-grid img {
   width: 100%;
   aspect-ratio: 1 / 1;
   object-fit: cover;
   display: block;
+  transition: transform 0.2s ease;
+}
+.photo-wrap:hover img {
+  transform: scale(1.1);
+}
+/* Project switching */
+.project-pane {
+  display: none;
+  padding: 0;
+}
+.project-pane.active {
+  display: block;
+}
+.project-pane h3 {
+  margin: 0 0 16px 0;
+}
+.project-switch {
+  color: var(--projects-border);
+  cursor: pointer;
+  margin-left: 8px;
 }

--- a/projects.html
+++ b/projects.html
@@ -1,3 +1,10 @@
-<h3>Anderson Memorial Bridge</h3>
-<div class="photo-grid" id="amb-photo-grid"></div>
-<span class="clicker"></span>
+<div class="projects-window">
+  <div class="project-pane active" id="amb">
+    <h3>Anderson Memorial Bridge <span class="project-switch" data-target="rhythm">&gt;&gt;&gt;</span></h3>
+    <div class="photo-grid" id="amb-photo-grid"></div>
+  </div>
+  <div class="project-pane" id="rhythm">
+    <h3>Rhythm of COVID-19 <span class="project-switch" data-target="amb">&gt;&gt;&gt;</span></h3>
+    <p>An audio-visual exploration of pandemic data rhythms.</p>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Remove Windows-style borders so project panes align with other content
- Replace retro tab buttons with `>>>` arrow links matching section accent color
- Simplify JS to activate panes via arrow toggles and load AMB photo grid on demand
- Add hover zoom and lazy loading for AMB photo grid images

## Testing
- `node --check nooahaha.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d53d87248325b9f81b13a9958c90