### PR TITLE
Fix project page and enable hover transition

### DIFF
--- a/nooahaha.css
+++ b/nooahaha.css
@@ -156,6 +156,7 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
     aspect-ratio: 1 / 1;
     object-fit: cover;
     display: block;
+    transition: transform 0.3s ease;
 }
 /* Retro project tabs */
 .projects-window {

--- a/projects.html
+++ b/projects.html
@@ -1,11 +1,29 @@
-
-<div class="projects-window">
-  <div class="project-pane active" id="amb">
-    <h3>Anderson Memorial Bridge <span class="project-switch" data-target="rhythm">&gt;&gt;&gt;</span></h3>
-    <div class="photo-grid" id="amb-photo-grid"></div>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Projects - Yedong Sh-Chen</title>
+  <link rel="stylesheet" href="./nooahaha.css" />
+</head>
+<body>
+  <div class="projects-window">
+    <div class="project-pane active" id="amb">
+      <h3>Anderson Memorial Bridge <span class="project-switch" data-target="rhythm">&gt;&gt;&gt;</span></h3>
+      <div class="photo-grid" id="amb-photo-grid"></div>
+    </div>
+    <div class="project-pane" id="rhythm">
+      <h3>Rhythm of COVID-19 <span class="project-switch" data-target="amb">&gt;&gt;&gt;</span></h3>
+      <p>An audio-visual exploration of pandemic data rhythms.</p>
+    </div>
   </div>
-  <div class="project-pane" id="rhythm">
-    <h3>Rhythm of COVID-19 <span class="project-switch" data-target="amb">&gt;&gt;&gt;</span></h3>
-    <p>An audio-visual exploration of pandemic data rhythms.</p>
-  </div>
-</div>
+  <script src="./nooahaha.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof initProjectTabs === 'function') {
+        initProjectTabs();
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Make `projects.html` a standalone page that loads site scripts and initializes project tabs on load
- Add transition to project image hover for smoother zoom

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6896eb7080348325adc6a9938fc36883