### PR TITLE
Fix project image hover and stray script

### DIFF
--- a/nooahaha.css
+++ b/nooahaha.css
@@ -152,6 +152,10 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
 .photo-wrap {
   overflow: hidden;
   position: relative;
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 /* Allow hovered photos to expand beyond the grid */
 .photo-wrap:hover {
@@ -159,11 +163,12 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
   z-index: 10;
 }
 .photo-grid img {
-    width: 100%;
-    aspect-ratio: 1 / 1;
-    object-fit: cover;
-    display: block;
-    transition: transform 0.3s ease, object-fit 0.3s ease;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.3s ease, object-fit 0.3s ease;
+  transform-origin: center center;
 }
 /* Retro project tabs */
 .projects-window {
@@ -202,9 +207,8 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
 }
 /* Enlarge and reveal full photo on hover */
 .photo-wrap:hover img {
-  transform: scale(1.1);
+  transform: scale(1.4);
   object-fit: contain;
-  aspect-ratio: auto;
 }
 /* Project switching */
 .project-pane {

--- a/projects.html
+++ b/projects.html
@@ -18,12 +18,5 @@
     </div>
   </div>
   <script src="./nooahaha.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      if (typeof initProjectTabs === 'function') {
-        initProjectTabs();
-      }
-    });
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove leftover inline script from `projects.html` causing visible text below projects
- Center project photos on hover and enlarge 40% instead of 10%

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896f057854483258c2f81d115002349