### PR TITLE
Center photo hover zoom and enlarge to 200%

### DIFF
--- a/nooahaha.css
+++ b/nooahaha.css
@@ -153,9 +153,6 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
   overflow: hidden;
   position: relative;
   aspect-ratio: 1 / 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 /* Allow hovered photos to expand beyond the grid */
 .photo-wrap:hover {
@@ -163,11 +160,15 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
   z-index: 10;
 }
 .photo-grid img {
+  position: absolute;
+  top: 50%;
+  left: 50%;
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
   transition: transform 0.3s ease, object-fit 0.3s ease;
+  transform: translate(-50%, -50%);
   transform-origin: center center;
 }
 /* Retro project tabs */
@@ -207,7 +208,7 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
 }
 /* Enlarge and reveal full photo on hover */
 .photo-wrap:hover img {
-  transform: scale(1.4);
+  transform: translate(-50%, -50%) scale(2);
   object-fit: contain;
 }
 /* Project switching */


### PR DESCRIPTION
## Summary
- Center images in project photo grid and enlarge on hover from the cell center
- Increase hover zoom to 200% for clearer viewing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896f25de394832588a9735bdf9e4066