### PR TITLE
Add CC BY-NC-SA notice to site footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
       </section>
     </main>
 
-    <div class="footer">© <span id="year"></span> nooahaha.com</div>
+      <div class="footer"><a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="noopener">CC BY-NC-SA 4.0</a> <span id="year"></span> © Yedong Sh-Chen</div>
   </div>
 
   <script src="./nooahaha.js?v=20250811"></script>


### PR DESCRIPTION
## Summary
- display Creative Commons BY-NC-SA 4.0 license notice in footer
- show dynamic year in footer without hard-coded start year

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689940af21b0832581903b4b8457c970