### PR TITLE
Add EALC Teaching Tips link to Projects page

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -16,8 +16,12 @@
       <div class="photo-grid" id="amb-photo-grid"></div>
     </div>
     <div class="project-pane" id="rhythm">
-      <h3>Rhythm of COVID-19 <span class="project-switch" data-target="amb">&gt;&gt;&gt;</span></h3>
+      <h3>Rhythm of COVID-19 <span class="project-switch" data-target="ealc">&gt;&gt;&gt;</span></h3>
       <p>An audio-visual exploration of pandemic data rhythms.</p>
+    </div>
+    <div class="project-pane" id="ealc">
+      <h3>EALC Teaching Tips <span class="project-switch" data-target="amb">&gt;&gt;&gt;</span></h3>
+      <p><a href="https://noah-c.github.io/Harvard-EALC-Teaching-TIps/" target="_blank" rel="noopener noreferrer">Visit the EALC Teaching Tips site</a>.</p>
     </div>
   </div>
   <script src="./nooahaha.js"></script>


### PR DESCRIPTION
## Summary
- Add EALC Teaching Tips project pane linking to the teaching tips website
- Ensure the link opens the site in a new browser tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e5957cf08325be80d02e700e6425