### PR TITLE
Ensure heart animation works across browsers

### DIFF
--- a/nooahaha.css
+++ b/nooahaha.css
@@ -241,12 +241,25 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
 
 /* Heart movement and transitions */
 .heart {
-  transition: left 1200ms cubic-bezier(0.25, 0.46, 0.45, 0.94), 
-              top 1200ms cubic-bezier(0.25, 0.46, 0.45, 0.94), 
+  -webkit-transition: left 1200ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                      top 1200ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                      -webkit-transform 1200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: left 1200ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
+              top 1200ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
               transform 1200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-.heart.shake { animation: heart-shake 2s ease; }
+.heart.shake {
+  -webkit-animation: heart-shake 2s ease;
+  animation: heart-shake 2s ease;
+}
+@-webkit-keyframes heart-shake {
+  0%, 100% { -webkit-transform: rotate(-45deg) scale(2) translate(0, 0); transform: rotate(-45deg) scale(2) translate(0, 0); }
+  20% { -webkit-transform: rotate(-45deg) scale(2) translate(1px, -1px); transform: rotate(-45deg) scale(2) translate(1px, -1px); }
+  40% { -webkit-transform: rotate(-45deg) scale(2) translate(-1px, 1px); transform: rotate(-45deg) scale(2) translate(-1px, 1px); }
+  60% { -webkit-transform: rotate(-45deg) scale(2) translate(1px, 1px); transform: rotate(-45deg) scale(2) translate(1px, 1px); }
+  80% { -webkit-transform: rotate(-45deg) scale(2) translate(-1px, -1px); transform: rotate(-45deg) scale(2) translate(-1px, -1px); }
+}
 @keyframes heart-shake {
   0%, 100% { transform: rotate(-45deg) scale(2) translate(0, 0); }
   20% { transform: rotate(-45deg) scale(2) translate(1px, -1px); }
@@ -264,8 +277,10 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
   background: #ff2b2b;
   opacity: 1;
   z-index: 9999;
+  -webkit-transform: translate(0,0) scale(1);
   transform: translate(0,0) scale(1);
   will-change: transform, opacity;
+  -webkit-transition: -webkit-transform 2500ms cubic-bezier(0.22, 1, 0.36, 1), opacity 2500ms ease;
   transition: transform 2500ms cubic-bezier(0.22, 1, 0.36, 1), opacity 2500ms ease;
 }
 .float-dot.light { background: #ff6b6b; width: 4px; height: 4px; }
@@ -275,6 +290,7 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
   position: fixed;
   left: 50%;
   top: 50%;
+  -webkit-transform: translate(-50%, -50%) scale(1);
   transform: translate(-50%, -50%) scale(1);
   z-index: 9999;
 }
@@ -285,6 +301,7 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
   width: 22px;
   height: 22px;
   background: #ff0000;
+  -webkit-transform: rotate(-45deg);
   transform: rotate(-45deg);
 }
 .heart::before,

--- a/nooahaha.js
+++ b/nooahaha.js
@@ -29,6 +29,7 @@ function startHeartBeat(el, baseline = 72){
     const y = ecgValue(t, hr);
     const scale = 1 + 0.3 * y;
     el.style.transform = `rotate(-45deg) scale(${scale})`;
+    el.style.webkitTransform = `rotate(-45deg) scale(${scale})`;
     raf = requestAnimationFrame(step);
   }
   raf = requestAnimationFrame(step);
@@ -51,6 +52,7 @@ function updateNavIndicator(id){
   indicator.style.width = `${linkRect.width}px`;
   indicator.style.height = `${linkRect.height}px`;
   indicator.style.transform = `translate(${x}px, ${y}px)`;
+  indicator.style.webkitTransform = `translate(${x}px, ${y}px)`;
   const root = getComputedStyle(document.documentElement);
   const colorVar = id === 'about' ? '--about-border' : id === 'writing' ? '--writing-border' : id === 'projects' ? '--projects-border' : '--talks-border';
   const color = root.getPropertyValue(colorVar).trim() || '#000';
@@ -167,8 +169,11 @@ function initWindowControls(){
   function cleanScreenState(){
     screen.classList.remove('is-minimizing');
     screen.style.transformOrigin = '';
+    screen.style.webkitTransformOrigin = '';
     screen.style.transition = '';
+    screen.style.webkitTransition = '';
     screen.style.transform = '';
+    screen.style.webkitTransform = '';
     screen.style.opacity = '';
   }
 
@@ -184,6 +189,7 @@ function initWindowControls(){
       const wrap = document.createElement('div');
       wrap.className = 'heart-wrap';
       wrap.style.transform = 'translate(-50%, -50%) scale(2.1)';
+      wrap.style.webkitTransform = 'translate(-50%, -50%) scale(2.1)';
       const heart = document.createElement('div');
       heart.className = 'heart';
       wrap.appendChild(heart);
@@ -204,7 +210,7 @@ function initWindowControls(){
             const d = document.createElement('div');
             d.className = 'float-dot' + (i % 3 === 0 ? ' light' : '');
             // Inline fallback styles so dots remain visible even if CSS hasn't loaded yet
-            d.style.cssText = `position:fixed;width:6px;height:6px;border-radius:50%;background:#ff2b2b;opacity:1;z-index:9999;transform:translate(0,0) scale(1);transition:transform 2500ms cubic-bezier(0.22,1,0.36,1),opacity 2500ms ease;`;
+            d.style.cssText = `position:fixed;width:6px;height:6px;border-radius:50%;background:#ff2b2b;opacity:1;z-index:9999;-webkit-transform:translate(0,0) scale(1);transform:translate(0,0) scale(1);-webkit-transition:-webkit-transform 2500ms cubic-bezier(0.22,1,0.36,1),opacity 2500ms ease;transition:transform 2500ms cubic-bezier(0.22,1,0.36,1),opacity 2500ms ease;`;
             if (i % 3 === 0) {
               d.style.background = '#ff6b6b';
               d.style.width = '4px';
@@ -221,6 +227,7 @@ function initWindowControls(){
               const driftX = Math.cos(angle) * distance;
               const driftY = Math.sin(angle) * distance;
               d.style.transform = `translate(${driftX}px, ${driftY}px) scale(${0.6 + Math.random()*0.4})`;
+              d.style.webkitTransform = `translate(${driftX}px, ${driftY}px) scale(${0.6 + Math.random()*0.4})`;
               d.style.opacity = '0';
             });
             setTimeout(() => d.remove(), 2600);


### PR DESCRIPTION
## Summary
- add WebKit-prefixed transitions, transforms, and keyframes to heart styles for better Safari compatibility
- mirror transform updates in JavaScript with webkit-prefixed properties so the beat and burst effects render across browsers

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/nooahaha-website/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a7e8158e948325a93dc79b13d13dd4