### PR TITLE
Fix COVID-19 rhythm video display

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
       <div class="footer"><a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="noopener">CC BY-NC-SA 4.0</a> <span id="year"></span> © Yedong Sh-Chen</div>
   </div>
 
-  <script src="./nooahaha.js?v=20250811"></script>
+  <script src="./nooahaha.js?v=20250822"></script>
   <script src="./typewriter.js?v=20250811"></script>
 </body>
-</html> 
+</html>

--- a/projects.html
+++ b/projects.html
@@ -18,12 +18,13 @@
     <div class="project-pane" id="rhythm">
       <h3>Rhythm of COVID-19 <span class="project-switch" data-target="ealc">&gt;&gt;&gt;</span></h3>
       <p>An audio-visual exploration of pandemic data rhythms.</p>
+      <iframe width="560" height="315" src="https://www.youtube.com/embed/Y2VuTiXkNII?si=QItinsFk2gJAbr9Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
     </div>
     <div class="project-pane" id="ealc">
       <h3>EALC Teaching Tips <span class="project-switch" data-target="amb">&gt;&gt;&gt;</span></h3>
       <p><a href="https://noah-c.github.io/Harvard-EALC-Teaching-TIps/" target="_blank" rel="noopener noreferrer">Visit the EALC Teaching Tips site</a>.</p>
     </div>
   </div>
-  <script src="./nooahaha.js"></script>
+  <script src="./nooahaha.js?v=20250822"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Bust cache for updated `nooahaha.js` so iframe support loads on all pages
- Guard footer year element and initialize tabs on load so project subpages render correctly

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a876b2b8508325a09b48ae7b8005d8