### PR TITLE
Add color-coded project grid with individual project pages

### DIFF
--- a/Projects/amb.html
+++ b/Projects/amb.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Anderson Memorial Bridge - Projects - Yedong Sh-Chen</title>
+  <link rel="stylesheet" href="../nooahaha.css" />
+</head>
+<body>
+  <h3>Anderson Memorial Bridge</h3>
+  <p>Since mid-summer 2018, I lived across the Charles River and crossed the John W. Weeks Footbridge almost every day to reach Harvard’s main campus. At some point — I can’t recall exactly when — I began to pause at the footbridge’s center line, photographing the bridge beside it, which I later learned was the Anderson Memorial Bridge.</p>
+  <p>Until the pandemic, when I moved away, I took more than two hundred images from this fixed vantage point, each preserving a fragment of light, weather, and season. Together they form a quiet chronicle of a place both constant and ever-changing.</p>
+  <p>You can refresh the page to see a different set of photos.</p>
+  <div class="photo-grid" id="amb-photo-grid"></div>
+  <script src="amb.js"></script>
+  <script>initAmbPhotoGrid();</script>
+</body>
+</html>

--- a/Projects/amb.js
+++ b/Projects/amb.js
@@ -1,0 +1,44 @@
+function shuffle(arr){
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+async function initAmbPhotoGrid(){
+  const grid = document.getElementById('amb-photo-grid');
+  if (!grid) return;
+  try {
+    const resp = await fetch('AMB%20Photos/photos.json', { cache: 'no-store' });
+    if (!resp.ok) throw new Error('Failed to fetch photo list');
+    const files = await resp.json();
+    const images = Array.isArray(files)
+      ? files.filter(name => /\.(jpe?g|png|gif)$/i.test(name))
+             .map(name => `AMB%20Photos/${encodeURIComponent(name)}`)
+      : [];
+    if (images.length === 0) return;
+    let selected;
+    if (images.length >= 36) {
+      shuffle(images);
+      selected = images.slice(0, 36);
+    } else {
+      selected = [];
+      for (let i = 0; i < 36; i++) {
+        const idx = Math.floor(Math.random() * images.length);
+        selected.push(images[idx]);
+      }
+    }
+    grid.innerHTML = '';
+    selected.forEach(src => {
+      const wrap = document.createElement('div');
+      wrap.className = 'photo-wrap';
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = 'Anderson Memorial Bridge photo';
+      img.loading = 'lazy';
+      wrap.appendChild(img);
+      grid.appendChild(wrap);
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}

--- a/Projects/ealc.html
+++ b/Projects/ealc.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>EALC Teaching Tips - Projects - Yedong Sh-Chen</title>
+  <link rel="stylesheet" href="../nooahaha.css" />
+</head>
+<body>
+  <h3>EALC Teaching Tips</h3>
+  <p><a href="https://noah-c.github.io/Harvard-EALC-Teaching-TIps/" target="_blank" rel="noopener noreferrer">Visit the EALC Teaching Tips site</a>.</p>
+</body>
+</html>

--- a/Projects/rhythm.html
+++ b/Projects/rhythm.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Rhythm of COVID-19 - Projects - Yedong Sh-Chen</title>
+  <link rel="stylesheet" href="../nooahaha.css" />
+</head>
+<body>
+  <h3>Rhythm of COVID-19</h3>
+  <p>An audio-visual exploration of pandemic data rhythms.</p>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/Y2VuTiXkNII?si=QItinsFk2gJAbr9Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</body>
+</html>

--- a/nooahaha.css
+++ b/nooahaha.css
@@ -220,6 +220,30 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
   transform: translate(-50%, -50%) scale(2);
   object-fit: contain;
 }
+/* Project grid */
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: 16px;
+  padding: 0;
+  margin: 0;
+}
+
+.project-card {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 4px;
+}
+
+.project-card:hover {
+  opacity: 0.8;
+}
+
+.card-amb { background: #ffa417; }
+.card-rhythm { background: #ff5a3c; }
+.card-ealc { background: #3ce1ff; }
+
 /* Project switching */
 .project-pane {
   display: none;

--- a/projects.html
+++ b/projects.html
@@ -1,30 +1,5 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Projects - Yedong Sh-Chen</title>
-  <link rel="stylesheet" href="./nooahaha.css" />
-</head>
-<body>
-  <div class="projects-window">
-    <div class="project-pane active" id="amb">
-      <h3>Anderson Memorial Bridge <span class="project-switch" data-target="rhythm">&gt;&gt;&gt;</span></h3>
-      <p class="project-intro">Since mid-summer 2018, I lived across the Charles River and crossed the John W. Weeks Footbridge almost every day to reach Harvard’s main campus. At some point — I can’t recall exactly when — I began to pause at the footbridge’s center line, photographing the bridge beside it, which I later learned was the Anderson Memorial Bridge.</p>
-      <p class="project-intro">Until the pandemic, when I moved away, I took more than two hundred images from this fixed vantage point, each preserving a fragment of light, weather, and season. Together they form a quiet chronicle of a place both constant and ever-changing.</p>
-      <p class="project-intro">You can refresh the page to see a different set of photos.</p>
-      <div class="photo-grid" id="amb-photo-grid"></div>
-    </div>
-    <div class="project-pane" id="rhythm">
-      <h3>Rhythm of COVID-19 <span class="project-switch" data-target="ealc">&gt;&gt;&gt;</span></h3>
-      <p>An audio-visual exploration of pandemic data rhythms.</p>
-      <iframe width="560" height="315" src="https://www.youtube.com/embed/Y2VuTiXkNII?si=QItinsFk2gJAbr9Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-    </div>
-    <div class="project-pane" id="ealc">
-      <h3>EALC Teaching Tips <span class="project-switch" data-target="amb">&gt;&gt;&gt;</span></h3>
-      <p><a href="https://noah-c.github.io/Harvard-EALC-Teaching-TIps/" target="_blank" rel="noopener noreferrer">Visit the EALC Teaching Tips site</a>.</p>
-    </div>
-  </div>
-  <script src="./nooahaha.js"></script>
-</body>
-</html>
+<div class="projects-grid">
+  <a href="./Projects/amb.html" class="project-card card-amb" aria-label="Anderson Memorial Bridge"></a>
+  <a href="./Projects/rhythm.html" class="project-card card-rhythm" aria-label="Rhythm of COVID-19"></a>
+  <a href="./Projects/ealc.html" class="project-card card-ealc" aria-label="EALC Teaching Tips"></a>
+</div>


### PR DESCRIPTION
## Summary
- Replace project pane toggles with a color-coded grid linking to project subpages
- Style new project grid and cards
- Create standalone pages for Anderson Memorial Bridge photos, Rhythm of COVID-19, and EALC Teaching Tips

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a87dd8ae4483259e326e1b76f6b098