### PR TITLE
Resize and refine project card hover styling

### DIFF
--- a/nooahaha.css
+++ b/nooahaha.css
@@ -223,10 +223,11 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
 /* Project grid */
 .projects-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  grid-template-columns: repeat(auto-fill, 120px);
   gap: 16px;
   padding: 0;
   margin: 0;
+  justify-content: center;
 }
 
 .project-card {
@@ -240,22 +241,31 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
   color: #000;
   text-align: center;
   border: 1px solid #000;
-  transition: background 0.3s ease, color 0.3s ease;
+  transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.project-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 .card-amb:hover {
   background: #ffa417;
   color: #fff;
+  border-color: #ffa417;
 }
 
 .card-rhythm:hover {
   background: #ff5a3c;
   color: #fff;
+  border-color: #ff5a3c;
 }
 
 .card-ealc:hover {
   background: #3ce1ff;
   color: #000;
+  border-color: #3ce1ff;
 }
 
 /* Project switching */


### PR DESCRIPTION
## Summary
- Shrink project cards to fixed 120px squares and center grid
- Add lift and shadow on hover with colored borders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a88b038e248325b3cd0f5a3701bb8c