### PR TITLE
Refine project list layout and navigation arrow placement

### DIFF
--- a/nooahaha.css
+++ b/nooahaha.css
@@ -221,26 +221,24 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
   object-fit: contain;
 }
 /* Project grid */
+
 .projects-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, 120px);
+  display: flex;
+  flex-direction: column;
   gap: 16px;
   padding: 0;
   margin: 0;
-  justify-content: center;
+  align-items: flex-start;
 }
 
 .project-card {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  aspect-ratio: 1 / 1;
+  display: inline-block;
+  padding: 8px 12px;
   border-radius: 4px;
   background: #fff;
   color: #000;
-  text-align: center;
-  border: 1px solid #000;
+  text-align: left;
+  border: 1px solid var(--border);
   transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease, transform 0.2s ease, box-shadow 0.2s ease;
   cursor: pointer;
 }

--- a/projects.html
+++ b/projects.html
@@ -8,7 +8,7 @@
   </div>
 
   <div class="project-pane" id="amb">
-    <h3>Anderson Memorial Bridge <span class="project-switch" data-target="overview">&lt;&lt;&lt;</span></h3>
+    <h3><span class="project-switch" data-target="overview">&lt;&lt;&lt;</span> Anderson Memorial Bridge</h3>
     <p>Since mid-summer 2018, I lived across the Charles River and crossed the John W. Weeks Footbridge almost every day to reach Harvard’s main campus. At some point — I can’t recall exactly when — I began to pause at the footbridge’s center line, photographing the bridge beside it, which I later learned was the Anderson Memorial Bridge.</p>
     <p>Until the pandemic, when I moved away, I took more than two hundred images from this fixed vantage point, each preserving a fragment of light, weather, and season. Together they form a quiet chronicle of a place both constant and ever-changing.</p>
     <p>You can refresh the page to see a different set of photos.</p>
@@ -16,13 +16,13 @@
   </div>
 
   <div class="project-pane" id="rhythm">
-    <h3>Rhythm of COVID-19 <span class="project-switch" data-target="overview">&lt;&lt;&lt;</span></h3>
+    <h3><span class="project-switch" data-target="overview">&lt;&lt;&lt;</span> Rhythm of COVID-19</h3>
     <p>An audio-visual exploration of pandemic data rhythms.</p>
     <iframe width="560" height="315" src="https://www.youtube.com/embed/Y2VuTiXkNII?si=QItinsFk2gJAbr9Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
   </div>
 
   <div class="project-pane" id="ealc">
-    <h3>EALC Teaching Tips <span class="project-switch" data-target="overview">&lt;&lt;&lt;</span></h3>
+    <h3><span class="project-switch" data-target="overview">&lt;&lt;&lt;</span> EALC Teaching Tips</h3>
     <p><a href="https://noah-c.github.io/Harvard-EALC-Teaching-TIps/" target="_blank" rel="noopener noreferrer">Visit the EALC Teaching Tips site</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Display project cards in a vertical list aligned with page content
- Use flexible card sizing with grey borders consistent with site container
- Move back-navigation arrows before project titles

## Testing
- `npx prettier -c projects.html nooahaha.css` *(fails: Code style issues found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a88fbf80fc83258897d1efc9c1ba6e