### PR TITLE
Fit project cards to content

### DIFF
--- a/nooahaha.css
+++ b/nooahaha.css
@@ -226,14 +226,15 @@ main ul { margin-bottom: 20px; list-style: none; padding-left: 0; }
 .projects-grid {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 16px;
   padding: 0;
   margin: 0;
 }
 
 .project-card {
-  display: block;
-  width: 100%;
+  display: inline-block;
+  max-width: 100%;
   padding: 8px 12px;
   border-radius: 4px;
   background: #fff;


### PR DESCRIPTION
## Summary
- Allow project cards to size to their text by dropping fixed width
- Prevent flex container from stretching cards to full width

## Testing
- `npx --yes prettier --check projects.html nooahaha.css`
- `npx --yes htmlhint projects.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b2718e448325b799c038a6c84a91